### PR TITLE
Switch to Supabase order polling

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,5 @@
-WEBSOCKET_SERVER_URL=ws://localhost:5001
+SUPABASE_PROJECT_ID=your-project-id
+SUPABASE_API_KEY=your-api-key
+SUPABASE_URL=https://your-project-id.supabase.co
+DEFAULT_PRINTER_NAME=your-printer-name
+DEBUG=True

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Windows용 데스크탑 주문 관리 및 프린터 통합 위젯입니다.
 
 ## 주요 기능
 
-- 실시간 WebSocket 주문 수신
+- Supabase를 이용한 주문 수신
 - GUI에 주문 내역 표시
 - 자동 영수증 출력
 - SQLite 주문 로그 저장
@@ -25,7 +25,9 @@ pip install -r requirements.txt
 2. 환경 변수 설정:
 `.env` 파일을 생성하고 다음 내용을 추가합니다:
 ```
-WEBSOCKET_SERVER_URL=ws://your-server:port
+SUPABASE_PROJECT_ID=your-project-id
+SUPABASE_API_KEY=your-api-key
+SUPABASE_URL=https://your-project-id.supabase.co
 DEFAULT_PRINTER_NAME=your-printer-name
 DEBUG=True
 ```

--- a/main.py
+++ b/main.py
@@ -28,6 +28,9 @@ def main():
     project_id = os.getenv('SUPABASE_PROJECT_ID')
     if not supabase_url and project_id:
         supabase_url = f"https://{project_id}.supabase.co"
+    if not supabase_url:
+        logging.critical("Supabase URL is not configured. Check .env")
+        sys.exit(1)
     logging.info(f"Supabase URL: {supabase_url}")
     
     # 데이터베이스 파일 위치 출력

--- a/main.py
+++ b/main.py
@@ -23,9 +23,12 @@ def main():
     # 환경 변수 로드
     load_dotenv()
     
-    # WebSocket 서버 포트 정보 출력
-    ws_url = os.getenv('WEBSOCKET_SERVER_URL', 'ws://localhost:5001')
-    logging.info(f"WebSocket 서버 URL: {ws_url}")
+    # Supabase 연결 정보 출력
+    supabase_url = os.getenv('SUPABASE_URL')
+    project_id = os.getenv('SUPABASE_PROJECT_ID')
+    if not supabase_url and project_id:
+        supabase_url = f"https://{project_id}.supabase.co"
+    logging.info(f"Supabase URL: {supabase_url}")
     
     # 데이터베이스 파일 위치 출력
     db_path = os.path.abspath("orders.db")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ PySide6>=6.5.0
 websockets>=11.0.3
 python-dotenv>=1.0.0
 pywin32>=305
-pyinstaller>=5.13.0 
+pyinstaller>=5.13.0
+requests>=2.31.0

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -3,7 +3,7 @@ from PySide6.QtCore import Qt
 from .order_widget import OrderWidget
 from .server_widget import ServerWidget
 import asyncio
-from ..websocket.client import WebSocketClient
+from ..supabase_client import SupabaseClient
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -26,11 +26,11 @@ class MainWindow(QMainWindow):
         self.order_widget = OrderWidget()
         layout.addWidget(self.order_widget)
 
-        # 💡 WebSocketClient 연결
-        self.ws_client = WebSocketClient()
+        # 💡 SupabaseClient 연결
+        self.ws_client = SupabaseClient()
         self.ws_client.order_received.connect(self.order_widget.add_order)
 
-        # 💡 WebSocket 실행 (비동기로 실행)
+        # 💡 Supabase 폴링 실행 (비동기로 실행)
         import threading
         threading.Thread(target=lambda: asyncio.run(self.ws_client.connect()), daemon=True).start()
         

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -3,7 +3,7 @@ from PySide6.QtCore import Qt
 from .order_widget import OrderWidget
 from .server_widget import ServerWidget
 import asyncio
-from ..supabase_client import SupabaseClient
+from src.supabase_client import SupabaseClient
 
 class MainWindow(QMainWindow):
     def __init__(self):

--- a/src/supabase_client.py
+++ b/src/supabase_client.py
@@ -1,0 +1,51 @@
+import os
+import asyncio
+import requests
+from PySide6.QtCore import QObject, Signal
+
+class SupabaseClient(QObject):
+    """Poll Supabase for new orders and emit them."""
+
+    order_received = Signal(dict)
+
+    def __init__(self, poll_interval=5):
+        super().__init__()
+        project_id = os.getenv("SUPABASE_PROJECT_ID")
+        self.base_url = os.getenv("SUPABASE_URL") or f"https://{project_id}.supabase.co"
+        self.api_key = os.getenv("SUPABASE_API_KEY")
+        self.poll_interval = poll_interval
+        self.running = False
+        self.last_seen_id = None
+
+    async def connect(self):
+        self.running = True
+        while self.running:
+            try:
+                await self._check_new_order()
+            except Exception as exc:
+                print(f"Supabase poll error: {exc}")
+            await asyncio.sleep(self.poll_interval)
+
+    async def _check_new_order(self):
+        headers = {
+            "apikey": self.api_key,
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        params = {
+            "select": "*",
+            "order": "created_at.desc",
+            "limit": "1",
+        }
+        resp = requests.get(f"{self.base_url}/rest/v1/order", headers=headers, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        if not data:
+            return
+        order = data[0]
+        if self.last_seen_id == order["order_id"]:
+            return
+        self.last_seen_id = order["order_id"]
+        self.order_received.emit(order)
+
+    def stop(self):
+        self.running = False


### PR DESCRIPTION
## Summary
- poll Supabase for new orders via new `SupabaseClient`
- update main window to use `SupabaseClient`
- log Supabase connection info in `main.py`
- document Supabase environment variables in README
- add `requests` to requirements
- provide `.env` example

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bbc4cb224832dac630138f6c13c4a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Supabase integration for order reception, replacing the previous WebSocket-based approach.
  - Added new environment variables for Supabase configuration and printer settings.
- **Documentation**
  - Updated setup and feature descriptions in the README to reflect Supabase usage and new environment variables.
- **Chores**
  - Added the `requests` library as a dependency.
  - Improved environment configuration and logging for Supabase connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->